### PR TITLE
Fix too large report error

### DIFF
--- a/run_action.py
+++ b/run_action.py
@@ -35,12 +35,20 @@ def make_markdown_table(array):
         markdown += str("-------------- | ")
     markdown += "\n"
 
+    markdown_characters = 0
+    max_characters = 65000
     for entry in array[1:]:
         markdown += str("| ")
         for e in entry:
             to_add = str(e) + str(" | ")
             markdown += to_add
         markdown += "\n"
+        markdown_characters += len(markdown)
+        if markdown_characters > max_characters:
+            markdown += "\n" + WARNING_SUFFIX + " "
+            markdown += "Results were omitted because the report was too large. "
+            markdown += "Please consider ignoring results below a certain threshold.\n"
+            break
 
     return markdown + "\n"
 


### PR DESCRIPTION
GitHub's maximum comment length of 65536 needs to be taken into account when posting the results.
For now, let's work around it by warning the user of omitted results when the report is too large. 

Fixes #11