### PR TITLE
Allow for user configurable message header

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ jobs:
           only_code: true
           # Leave only one comment with the report and update it for consecutive runs
           one_comment: true
+          # The message to be displayed at the start of the report
+          header_message_start: "The following files have a similarity above the threshold:"
 ```
 ## Using duplicate-code-check with pre-commit
 To use Duplicate Code Detection Tool as a pre-commit hook with [pre-commit](https://pre-commit.com/) add the following to your `.pre-commit-config.yaml` file:

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,13 @@ inputs:
     description: 'Duplication report will be left as a single comment, which will be updated, instead of multiple ones'
     required: false
     default: false
+  header_message_start:
+    description: 'The message to be displayed at the start of the duplication report.
+                  It is used by the bot to identify previous reports and update them, so it must be unique.
+                  If you want to use the Action in multiple steps of the same workflow,
+                  then you can change this message in each step to avoid conflicts'
+    required: false
+    default: '## 📌 Duplicate code detection tool report'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/run_action.py
+++ b/run_action.py
@@ -164,7 +164,7 @@ def main():
     files_url_prefix = "https://github.com/%s/blob/%s/" % (repo, args.latest_head)
     warn_threshold = os.environ.get("INPUT_WARN_ABOVE")
 
-    header_message_start = "## 📌 Duplicate code detection tool report\n"
+    header_message_start = os.environ.get("INPUT_HEADER_MESSAGE_START") + "\n"
     message = header_message_start
     message += "The [tool](https://github.com/platisd/duplicate-code-detection-tool)"
     message += " analyzed your source code and found the following degree of"


### PR DESCRIPTION
Allow users to specify if they want the report's header. This will allow them to customize the behavior and enable multiple Action runs in different steps of the same workflow as long as each title is unique.

Fixes #32